### PR TITLE
Remove AWS Access Key credentials from terraform workflow definition

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,8 +13,8 @@ env:
   CONSUL_HTTP_TOKEN: ${{ secrets.CONSUL_HTTP_TOKEN }}      # Repository specific, contact @bencord0 to rotate
   ARTIFACT_SECRET_KEY: ${{ secrets.ARTIFACT_SECRET_KEY }}  # Random, e.g. $(uuidgen); not stored, free to rotate at any time
 
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+permissions:
+  id-token: write
 
 jobs:
   terraform-plan:
@@ -44,6 +44,16 @@ jobs:
 
           terraform --version
         fi
+
+    # https://github.blog/changelog/2021-10-27-github-actions-secure-cloud-deployments-with-openid-connect/
+    - name: Configure AWS Credentials
+      run: |
+        echo AWS_ROLE_ARN="arn:aws:iam::055237546114:role/meta-terraform-plans-ro" >> $GITHUB_ENV
+        echo AWS_WEB_IDENTITY_TOKEN_FILE=webidentity.json                          >> $GITHUB_ENV
+        echo AWS_DEFAULT_REGION=eu-west-2                                          >> $GITHUB_ENV
+        source $GITHUB_ENV
+
+        curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > webidentity.json
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init

--- a/modules/roles/meta-terraform-plans/role.tf
+++ b/modules/roles/meta-terraform-plans/role.tf
@@ -21,13 +21,13 @@ data "aws_iam_policy_document" "assume-meta-terraform-plans-ro" {
       ]
     }
 
-    # Match the specific repository
+    # Match the specific repository, all branches including pull requests
     condition {
-      test     = "StringEquals"
-      variable = "token.actions.githubusercontent.com:repository"
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
 
       values = [
-        var.github_repository,
+        "repo:${var.github_repository}:*",
       ]
     }
   }


### PR DESCRIPTION
They're still available through the `environment`, which requires manual approval to use.